### PR TITLE
feat: support both field and label selector in Kubernetes collector

### DIFF
--- a/chaosblade-box-collector/chaosblade-box-collector-api/src/main/java/com/alibaba/chaosblade/box/collector/model/Query.java
+++ b/chaosblade-box-collector/chaosblade-box-collector-api/src/main/java/com/alibaba/chaosblade/box/collector/model/Query.java
@@ -30,6 +30,10 @@ public class Query {
 
     private String podName;
 
+    private String fieldSelector;
+
+    private String labelSelector;
+
     private Long clusterId;
 
     private String config;

--- a/chaosblade-box-collector/chaosblade-box-collector-kubeapi/src/main/java/com/alibaba/chaosblade/box/collector/kubeapi/KubeApiContainerCollector.java
+++ b/chaosblade-box-collector/chaosblade-box-collector-kubeapi/src/main/java/com/alibaba/chaosblade/box/collector/kubeapi/KubeApiContainerCollector.java
@@ -55,6 +55,11 @@ public class KubeApiContainerCollector implements ContainerCollector, Initializi
 
     @Override
     public CompletableFuture<List<Container>> collect(Query query) {
+        String fieldSelector = StrUtil.isBlank(query.getFieldSelector()) ?
+                String.format("metadata.name=%s", query.getPodName()) :
+                String.format("metadata.name=%s,%s", query.getPodName(), query.getFieldSelector());
+        String labelSelector = query.getLabelSelector();
+
         CompletableFuture<List<Container>> future = new CompletableFuture<>();
         CoreV1Api api;
         try {
@@ -64,7 +69,8 @@ public class KubeApiContainerCollector implements ContainerCollector, Initializi
                 ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(query.getConfig().getBytes());
                 api = new CoreV1Api(Config.fromConfig(byteArrayInputStream));
             }
-            api.listPodForAllNamespacesAsync(null, null, String.format("metadata.name=%s", query.getPodName()), null,
+
+            api.listPodForAllNamespacesAsync(null, null, fieldSelector, labelSelector,
                     null, null, null, null, null,
                     new ApiCallback<V1PodList>() {
                         @Override

--- a/chaosblade-box-collector/chaosblade-box-collector-kubeapi/src/main/java/com/alibaba/chaosblade/box/collector/kubeapi/KubeApiPodCollector.java
+++ b/chaosblade-box-collector/chaosblade-box-collector-kubeapi/src/main/java/com/alibaba/chaosblade/box/collector/kubeapi/KubeApiPodCollector.java
@@ -63,7 +63,7 @@ public class KubeApiPodCollector implements PodCollector, InitializingBean {
                 ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(query.getConfig().getBytes());
                 api = new CoreV1Api(Config.fromConfig(byteArrayInputStream));
             }
-            api.listPodForAllNamespacesAsync(null, null, null, null,
+            api.listPodForAllNamespacesAsync(null, null, query.getFieldSelector(), query.getLabelSelector(),
                     null, null, null, null, null,
                     new ApiCallback<V1PodList>() {
                         @Override

--- a/chaosblade-box-service/src/main/java/com/alibaba/chaosblade/box/service/collect/CollectorTimer.java
+++ b/chaosblade-box-service/src/main/java/com/alibaba/chaosblade/box/service/collect/CollectorTimer.java
@@ -88,6 +88,12 @@ public class CollectorTimer implements InitializingBean {
     @Value("${chaos.collector.period}")
     private Integer period;
 
+    @Value("${chaos.collector.search.fieldSelector}")
+    private String fieldSelector;
+
+    @Value("${chaos.collector.search.labelSelector}")
+    private String labelSelector;
+
     @Autowired
     private ApplicationContext applicationContext;
 
@@ -193,8 +199,10 @@ public class CollectorTimer implements InitializingBean {
                     q.setClusterId(query.getClusterId());
                     q.setConfig(query.getConfig());
                     q.setNodeName(node.getNodeName());
-                    CompletableFuture<List<Pod>> future = collector.collect(q);
+                    q.setFieldSelector(fieldSelector) ;
+                    q.setLabelSelector(labelSelector);
 
+                    CompletableFuture<List<Pod>> future = collector.collect(q);
                     QueryWrapper<DeviceDO> queryWrapper = QueryWrapperBuilder.build();
                     queryWrapper.lambda().eq(DeviceDO::getType, DeviceType.POD.getCode());
                     deviceMapper.update(DeviceDO.builder().lastPingTime(DateUtil.date()).build(), queryWrapper);
@@ -260,6 +268,8 @@ public class CollectorTimer implements InitializingBean {
                     q.setClusterId(query.getClusterId());
                     q.setConfig(query.getConfig());
                     q.setPodName(devicePod.getPodName());
+                    q.setFieldSelector(fieldSelector) ;
+                    q.setLabelSelector(labelSelector);
 
                     CompletableFuture<List<Container>> future = collector.collect(q);
                     future.handle((containers, e) -> {

--- a/chaosblade-box-web/src/main/resources/application.yml
+++ b/chaosblade-box-web/src/main/resources/application.yml
@@ -61,6 +61,9 @@ chaos:
     enable: false
     type: kube_api
     period: 30
+    search:
+      fieldSelector:
+      labelSelector:
     prometheus:
       api:
   metric:


### PR DESCRIPTION
Issue:
  If the amount of pods reach about 1k in target Kubernetes cluster, the current method to fetch all of pods will be potential to cause CPU SPIKE in API Server.
Enhancement:
  2 additional configuration items provided in application.yaml, can be used to limit the search withing one Namespace, to low down the pressure.
Test:
  already test in local & UAT env in my company
Link:
  #57 
@tiny-x 