### PR TITLE
Refactor RedisCacheTemplate injection to be optional

### DIFF
--- a/chaosblade-box-service/src/main/java/com/alibaba/chaosblade/box/service/command/guard/ExperimentGuardMetricLoadCommand.java
+++ b/chaosblade-box-service/src/main/java/com/alibaba/chaosblade/box/service/command/guard/ExperimentGuardMetricLoadCommand.java
@@ -45,7 +45,8 @@ public class ExperimentGuardMetricLoadCommand
 
   @Autowired private ExperimentGuardInstanceService experimentGuardInstanceService;
 
-  @Autowired private RedisCacheTemplate redisTemplate;
+  @Autowired(required = false)
+  private RedisCacheTemplate redisTemplate;
 
   @Override
   public ExperimentGuardMonitorMetricResultEntity internalExecute(
@@ -94,6 +95,9 @@ public class ExperimentGuardMetricLoadCommand
   private ExperimentGuardMonitorMetricResultEntity
       getExperimentGuardMonitorMetricResultEntityFormRedis(
           ExperimentGuardInstanceDO experimentGuardInstanceDO) {
+    if (redisTemplate == null) {
+      return new ExperimentGuardMonitorMetricResultEntity();
+    }
     try {
       Serializable serializable =
           redisTemplate.prefixGet(

--- a/chaosblade-box-service/src/main/java/com/alibaba/chaosblade/box/service/command/task/ExperimentTaskGuardInfoQueryCommand.java
+++ b/chaosblade-box-service/src/main/java/com/alibaba/chaosblade/box/service/command/task/ExperimentTaskGuardInfoQueryCommand.java
@@ -51,7 +51,8 @@ public class ExperimentTaskGuardInfoQueryCommand
 
   @Autowired private ExperimentChecker experimentChecker;
 
-  @Autowired private RedisCacheTemplate redisTemplate;
+  @Autowired(required = false)
+  private RedisCacheTemplate redisTemplate;
 
   @Autowired private ExperimentGuardInstanceRepository experimentGuardInstanceRepository;
 
@@ -152,6 +153,9 @@ public class ExperimentTaskGuardInfoQueryCommand
   private ExperimentGuardMonitorMetricResultEntity
       getExperimentGuardMonitorMetricResultEntityFormRedis(
           ExperimentGuardInstanceDO experimentGuardInstanceDO) {
+    if (redisTemplate == null) {
+      return new ExperimentGuardMonitorMetricResultEntity();
+    }
     try {
       Serializable serializable =
           redisTemplate.prefixGet(

--- a/chaosblade-box-service/src/main/java/com/alibaba/chaosblade/box/service/impl/ExperimentGuardInstanceServiceImpl.java
+++ b/chaosblade-box-service/src/main/java/com/alibaba/chaosblade/box/service/impl/ExperimentGuardInstanceServiceImpl.java
@@ -34,7 +34,8 @@ public class ExperimentGuardInstanceServiceImpl implements ExperimentGuardInstan
 
   @Autowired private ExperimentGuardInstanceRepository experimentGuardInstanceRepository;
 
-  @Autowired private RedisCacheTemplate redisTemplate;
+  @Autowired(required = false)
+  private RedisCacheTemplate redisTemplate;
 
   @Override
   public boolean addExperimentGuardInstance(ExperimentGuardInstanceDO experimentGuardInstanceDO) {
@@ -45,16 +46,18 @@ public class ExperimentGuardInstanceServiceImpl implements ExperimentGuardInstan
           experimentGuardInstanceDO.getValue();
       experimentGuardInstanceDO.setValue(null);
       experimentGuardInstanceRepository.add(experimentGuardInstanceDO);
-      try {
-        redisTemplate.prefixPut(
-            PRE,
-            experimentGuardInstanceDO.getInstanceId(),
-            experimentGuardMonitorMetricResultEntity);
-      } catch (Exception e) {
-        log.warn(
-            "Failed to save experiment guard monitor metric to Redis, instanceId: {}, error: {}",
-            experimentGuardInstanceDO.getInstanceId(),
-            e.getMessage());
+      if (redisTemplate != null) {
+        try {
+          redisTemplate.prefixPut(
+              PRE,
+              experimentGuardInstanceDO.getInstanceId(),
+              experimentGuardMonitorMetricResultEntity);
+        } catch (Exception e) {
+          log.warn(
+              "Failed to save experiment guard monitor metric to Redis, instanceId: {}, error: {}",
+              experimentGuardInstanceDO.getInstanceId(),
+              e.getMessage());
+        }
       }
       return true;
     }
@@ -71,16 +74,18 @@ public class ExperimentGuardInstanceServiceImpl implements ExperimentGuardInstan
           experimentGuardInstanceDO.getValue();
       experimentGuardInstanceDO.setValue(null);
       experimentGuardInstanceRepository.update(experimentGuardInstanceDO);
-      try {
-        redisTemplate.prefixPut(
-            PRE,
-            experimentGuardInstanceDO.getInstanceId(),
-            experimentGuardMonitorMetricResultEntity);
-      } catch (Exception e) {
-        log.warn(
-            "Failed to update experiment guard monitor metric to Redis, instanceId: {}, error: {}",
-            experimentGuardInstanceDO.getInstanceId(),
-            e.getMessage());
+      if (redisTemplate != null) {
+        try {
+          redisTemplate.prefixPut(
+              PRE,
+              experimentGuardInstanceDO.getInstanceId(),
+              experimentGuardMonitorMetricResultEntity);
+        } catch (Exception e) {
+          log.warn(
+              "Failed to update experiment guard monitor metric to Redis, instanceId: {}, error: {}",
+              experimentGuardInstanceDO.getInstanceId(),
+              e.getMessage());
+        }
       }
       return true;
     }


### PR DESCRIPTION
- Updated the injection of `RedisCacheTemplate` in `ExperimentGuardMetricLoadCommand`, `ExperimentTaskGuardInfoQueryCommand`, and `ExperimentGuardInstanceServiceImpl` to be optional by setting `required = false`.
- Added null checks for `redisTemplate` in relevant methods to prevent NullPointerExceptions and ensure graceful handling when the Redis cache is unavailable.

These changes enhance the robustness of the service commands by allowing them to function without a Redis cache, improving overall stability.